### PR TITLE
Add a skill for claude code and codex to use Erbium, packaged inside erbium

### DIFF
--- a/erbium/docker/docker-compose.yaml
+++ b/erbium/docker/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - ./motd:/etc/motd:ro
       - ./venv.sh:/etc/profile.d/venv.sh:ro
       - ./backup-output.sh:/usr/local/bin/backup-output.sh:ro
+      - ./skills:/opt/erbium-skills:ro
       - S:/erbium_input:/workspace/input:ro
       - S:/erbium_output:/workspace/output
       - S:/erbium_backup:/workspace/backup
@@ -44,6 +45,9 @@ services:
               groupadd -f render
               usermod -aG video,render access || true
               chown -R access:access /workspace/app /workspace/output /workspace/venv /usr/local/lib/node_modules
+              su - access -c "mkdir -p ~/.claude/skills/use-erbium ~/.codex/skills/use-erbium"
+              su - access -c "ln -sfn /opt/erbium-skills/use-erbium/SKILL.md ~/.claude/skills/use-erbium/SKILL.md"
+              su - access -c "ln -sfn /opt/erbium-skills/use-erbium/SKILL.md ~/.codex/skills/use-erbium/SKILL.md"
               if [ ! -x /workspace/venv/bin/python ]; then
                 su - access -c "python3.12 -m venv /workspace/venv"
                 su - access -c "/workspace/venv/bin/pip install --upgrade pip"

--- a/erbium/docker/skills/use-erbium/SKILL.md
+++ b/erbium/docker/skills/use-erbium/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-erbium
-description: Guidelines for running ML research experiments on Erbium, a remote VM accessed via Jupyter. Use when the user mentions Erbium, runs training/eval/inference on this machine, asks where to put model weights, datasets, predictions, or metrics, or needs to know GPU usage limits or the input/output directory layout.
+description: Guidelines for running ML research experiments on Erbium, a remote VM accessed via Jupyter. Use when the user mentions Erbium, runs training/eval/inference on this machine, asks where to put source code, model weights, datasets, predictions, or metrics, or needs to know GPU usage limits or the /workspace directory layout (app/input/output/venv).
 ---
 
 # Use Erbium
@@ -15,24 +15,28 @@ Erbium is the remote computer you are currently running on. Users connect to it 
 
 ## Filesystem layout
 
-All project data lives under `/workspace`, split into inputs and outputs:
+All project data lives under `/workspace`. There are four persistent folders — everything in them survives container restarts:
 
 ```
+/workspace/app/<project_name>/      # source code / working tree for the project
 /workspace/input/<project_name>/    # read-only-ish: pretrained weights, datasets
 /workspace/output/<project_name>/   # writable: metrics, predictions, trained weights
+/workspace/venv/                    # shared Python virtualenv (pip-installed deps)
 ```
 
 Rules:
 
-- **One folder per research project**, named after the project, mirrored under both `input/` and `output/`. Use the same `<project_name>` on both sides.
+- **One folder per research project**, named after the project, mirrored under `app/`, `input/`, and `output/`. Use the same `<project_name>` on all three sides.
+- **`/workspace/app/<project>/`** holds the project's *code*: cloned repo, scripts, notebooks, configs. This is where you `cd` to run things. Keep code here, not in `input/` or `output/`.
 - **`/workspace/input/<project>/`** holds things that come *into* the experiment: pretrained model weights, tokenizers, raw or preprocessed datasets. Treat as a stable cache — don't overwrite unless you mean to.
 - **`/workspace/output/<project>/`** holds things the experiment *produces*: training checkpoints, eval metrics (json/csv), inference predictions, plots, logs. Anything reproducible from code + inputs belongs here.
-- Do not write experiment artifacts to the project's source directory or to `$HOME`. Keep code separate from data.
+- **`/workspace/venv/`** is a single Python venv shared across all projects. Install deps here with `pip install ...`; do not create per-project venvs unless dependency conflicts force it.
+- Do not write experiment artifacts to `app/<project>/` or to `$HOME`. Keep code separate from data.
 
 ## When starting a new project
 
 1. Pick a short, lowercase `<project_name>` (e.g. `llmoe_baseline_avg_pooling`).
-2. Create both `/workspace/input/<project_name>/` and `/workspace/output/<project_name>/` before the first run.
+2. Create `/workspace/app/<project_name>/`, `/workspace/input/<project_name>/`, and `/workspace/output/<project_name>/` before the first run.
 3. If you're unsure which `<project_name>` to use, ask the user rather than guessing — name collisions are annoying to fix later.
 
 ## Quick checks before a long run

--- a/erbium/docker/skills/use-erbium/SKILL.md
+++ b/erbium/docker/skills/use-erbium/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: use-erbium
+description: Guidelines for running ML research experiments on Erbium, a remote VM accessed via Jupyter. Use when the user mentions Erbium, runs training/eval/inference on this machine, asks where to put model weights, datasets, predictions, or metrics, or needs to know GPU usage limits or the input/output directory layout.
+---
+
+# Use Erbium
+
+Erbium is the remote computer you are currently running on. Users connect to it through a small remoting tool and drive ML research experiments from Jupyter. The conventions below keep multiple projects and users from stepping on each other.
+
+## GPU usage
+
+- Cap each job at **95% of total GPU memory / utilization**. Leave at least 5% headroom so other processes (and the OS) stay responsive.
+- Before launching a long run, check current usage with `nvidia-smi`. If existing processes already consume significant GPU, scale your job down or wait.
+- For PyTorch, prefer setting an explicit fraction (e.g. `torch.cuda.set_per_process_memory_fraction(0.95)`) or batch-size limits over relying on dynamic allocation.
+
+## Filesystem layout
+
+All project data lives under `/workspace`, split into inputs and outputs:
+
+```
+/workspace/input/<project_name>/    # read-only-ish: pretrained weights, datasets
+/workspace/output/<project_name>/   # writable: metrics, predictions, trained weights
+```
+
+Rules:
+
+- **One folder per research project**, named after the project, mirrored under both `input/` and `output/`. Use the same `<project_name>` on both sides.
+- **`/workspace/input/<project>/`** holds things that come *into* the experiment: pretrained model weights, tokenizers, raw or preprocessed datasets. Treat as a stable cache — don't overwrite unless you mean to.
+- **`/workspace/output/<project>/`** holds things the experiment *produces*: training checkpoints, eval metrics (json/csv), inference predictions, plots, logs. Anything reproducible from code + inputs belongs here.
+- Do not write experiment artifacts to the project's source directory or to `$HOME`. Keep code separate from data.
+
+## When starting a new project
+
+1. Pick a short, lowercase `<project_name>` (e.g. `llmoe_baseline_avg_pooling`).
+2. Create both `/workspace/input/<project_name>/` and `/workspace/output/<project_name>/` before the first run.
+3. If you're unsure which `<project_name>` to use, ask the user rather than guessing — name collisions are annoying to fix later.
+
+## Quick checks before a long run
+
+- `nvidia-smi` — confirm you have GPU headroom and no orphan processes.
+- `df -h /workspace` — confirm there's space for checkpoints/outputs.
+- Output path is under `/workspace/output/<project>/`, not the code dir or `/tmp`.


### PR DESCRIPTION
Bundles the use-erbium skill into the Erbium image so Claude Code and Codex pick it up automatically for every user that SSHes into a running container — no per-host or per-user setup required.

Changes

 - New skill file: erbium/docker/skills/use-erbium/SKILL.md. Documents Erbium's GPU usage cap (95%), /workspace/input/<project>/ vs /workspace/output/<project>/ filesystem layout,
  new-project setup, and pre-run sanity checks. Single source of truth, lives in the repo.
- docker-compose.yaml:
  - Read-only bind-mount of the skills directory into the container: ./skills:/opt/erbium-skills:ro.
  - On container start, symlink the skill into both tools' config dirs for the access user:
    - ~/.claude/skills/use-erbium/SKILL.md → /opt/erbium-skills/use-erbium/SKILL.md
    - ~/.codex/skills/use-erbium/SKILL.md → /opt/erbium-skills/use-erbium/SKILL.md

  Why this shape

  - One file, two symlinks → editing the skill once updates both tools.
  - Read-only mount → users can't accidentally clobber the skill from inside the container.
  - Done at startup, per-user → works for the access user that JupyterLab and SSH already run as.